### PR TITLE
Support setting a custom http.Client in darksky.

### DIFF
--- a/darksky.go
+++ b/darksky.go
@@ -2,6 +2,8 @@ package darksky
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -17,11 +19,16 @@ type DarkSky interface {
 
 type darkSky struct {
 	ApiKey string
+	Client *http.Client
 }
 
 // New creates a new DarkSky client
 func New(apiKey string) DarkSky {
-	return &darkSky{apiKey}
+	return &darkSky{apiKey, &http.Client{}}
+}
+
+func NewWithClient(apiKey string, client *http.Client) DarkSky {
+	return &darkSky{apiKey, client}
 }
 
 // Forecast request a forecast
@@ -30,7 +37,7 @@ func (d *darkSky) Forecast(request ForecastRequest) (ForecastResponse, error) {
 
 	url := d.buildRequestUrl(request)
 
-	err := get(url, &response)
+	err := get(d.Client, url, &response)
 
 	return response, err
 }

--- a/rest.go
+++ b/rest.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 )
 
-func get(url string, output interface{}) error {
+func get(client *http.Client, url string, output interface{}) error {
 	req, err := http.NewRequest("GET", url, nil)
 
 	if err != nil {
@@ -19,7 +19,6 @@ func get(url string, output interface{}) error {
 	req.Header.Add("Content-Type", "application/json; charset=utf-8")
 	req.Header.Add("Accept-Encoding", "gzip")
 
-	client := http.Client{}
 	response, err := client.Do(req)
 
 	if err != nil {


### PR DESCRIPTION
This adds support for the end-user setting a custom http.Client. This
is useful for setting timeouts when making API requests.

Thanks for the library, Shawn! I'm working on a hobby project and it was great to find this out there.