### PR TITLE
Apple WeatherKit API client in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # DarkSky
-
-
 [![GoDoc](https://godoc.org/github.com/shawntoffel/darksky?status.svg)](https://godoc.org/github.com/shawntoffel/darksky) [![Go Report Card](https://goreportcard.com/badge/github.com/shawntoffel/darksky)](https://goreportcard.com/report/github.com/shawntoffel/darksky) [![CircleCI](https://circleci.com/gh/shawntoffel/darksky.svg?style=svg)](https://circleci.com/gh/shawntoffel/darksky)
 
 Dark Sky API client in Go https://darksky.net/dev/docs
+
+### A note on Apple Weather
+DarkSky's technology has been integrated into Apple Weather. 
+I've started a separate project [go-weatherkit](https://github.com/shawntoffel/go-weatherkit) for Go client development against Apple's new [WeatherKit](https://developer.apple.com/weatherkit/) REST API. 
 
 ### Installing
 
@@ -43,4 +45,11 @@ request := darksky.ForecastRequest{
 Get the forecast
 ```go
 forecast, err := client.Forecast(request)
+```
+
+### Configuration
+
+A different API URL may be targeted using the `BaseUrl` package scoped variable
+```go
+darksky.BaseUrl = "https://api.darksky.net/forecast"
 ```


### PR DESCRIPTION
Updated README with a note on Apple Weather & BaseUrl configuration. 

Since DarkSky's technology has been integrated into Apple Weather, a separate project has been started for Go client development against Apple's new WeatherKit REST API here: https://github.com/shawntoffel/go-weatherkit
